### PR TITLE
[Map] Add base map composable's fundamentals

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,3 +23,14 @@ if ! git diff --name-only --cached --relative \
     printf '\nktlint check failed.\nPlease check your code before commit!\n'
   exit 1
 fi
+
+# api checking
+./gradlew apiCheck -q
+API_CHECK_EXIT_CODE=$?
+if [ $EXIT_CODE -ne 0 ]; then
+  echo "apiCheck Failed. check your api"
+
+  exit $API_CHECK_EXIT_CODE
+fi
+
+exit 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,4 +3,12 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.parcelize) apply false
+
+    alias(libs.plugins.dokka)
+    alias(libs.plugins.kotlin.binaryCompatibility)
+}
+
+apiValidation {
+    ignoredProjects.addAll(listOf("sample-app"))
+    nonPublicMarkers.add("kotlin.PublishedApi")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -25,6 +25,9 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
+# suppress experimental compileSdk=34 until agp supported
+android.suppressUnsupportedCompileSdk=34
+
 # Build Features
 android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.buildconfig=false

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,33 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory
+org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -XX:MaxMetaspaceSize=512m -Dkotlin.daemon.jvm.options=-XX:MaxMetaspaceSize=1g -Dlint.nullness.ignore-deprecated=true -Dfile.encoding=UTF-8
+# https://docs.gradle.org/current/userguide/build_cache.html
+org.gradle.caching=true
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+org.gradle.parallel=true
+# AndroidX package structure to make it clearer which packages are bundled with the
+# Android operating system, and which are packaged with your app"s APK
+# https://developer.android.com/topic/libraries/support-library/androidx-rn
+android.useAndroidX=true
+# Kotlin code style for this project: "official" or "obsolete":
+kotlin.code.style=official
+# Enables namespacing of each library's R class so that its R class includes only the
+# resources declared in the library itself and none from the library's dependencies,
+# thereby reducing the size of the R class for that library
+android.nonTransitiveRClass=true
+
+# Build Features
+android.defaults.buildfeatures.aidl=false
+android.defaults.buildfeatures.buildconfig=false
+android.defaults.buildfeatures.renderscript=false
+android.defaults.buildfeatures.resvalues=false
+android.defaults.buildfeatures.shaders=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 # kotlin
 kotlin = "1.9.0"
 kotlin_coroutines = "1.7.1"
+kotlin_binaryCompatibility = "0.13.2"
 # android
 android_gradlePlugin = "8.1.0"
 android_buildCacheFixPlugin = "2.7.0"
@@ -21,6 +22,7 @@ android_application = { id = "com.android.application", version.ref = "android_g
 android_library = { id = "com.android.library", version.ref = "android_gradlePlugin" }
 kotlin_android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin_parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+kotlin_binaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlin_binaryCompatibility" }
 
 android_buildCacheFix = { id = "org.gradle.android.cache-fix", version.ref = "android_buildCacheFixPlugin" }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,9 @@ androidx_compose_foundation = "1.5.0"
 # map
 kakao_vectormap = "2.5.0"
 
+# dokka
+dokka = "1.8.20"
+
 [plugins]
 android_application = { id = "com.android.application", version.ref = "android_gradlePlugin" }
 android_library = { id = "com.android.library", version.ref = "android_gradlePlugin" }
@@ -20,6 +23,8 @@ kotlin_android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin_parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 
 android_buildCacheFix = { id = "org.gradle.android.cache-fix", version.ref = "android_buildCacheFixPlugin" }
+
+dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 
 [libraries]
 # kotlin

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,10 @@ androidx_compose_foundation = "1.5.0"
 # map
 kakao_vectormap = "2.5.0"
 
+# ktlint
+ktlint_plugin = "11.5.1"
+ktlint = "0.50.0"
+
 # dokka
 dokka = "1.8.20"
 
@@ -25,6 +29,8 @@ kotlin_parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin_binaryCompatibility = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlin_binaryCompatibility" }
 
 android_buildCacheFix = { id = "org.gradle.android.cache-fix", version.ref = "android_buildCacheFixPlugin" }
+
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint_plugin" }
 
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 

--- a/vectormap-compose/api/vectormap-compose.api
+++ b/vectormap-compose/api/vectormap-compose.api
@@ -1,0 +1,176 @@
+public final class io/hlab/vectormap/compose/KakaoMapKt {
+	public static final fun KakaoMap (Landroidx/compose/ui/Modifier;Lio/hlab/vectormap/compose/settings/MapInitialOptions;Lio/hlab/vectormap/compose/settings/MapViewSettings;Lio/hlab/vectormap/compose/settings/MapGestureSettings;Ljava/lang/String;Landroidx/compose/foundation/layout/PaddingValues;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+}
+
+public final class io/hlab/vectormap/compose/internal/MapEventListeners {
+	public static final field $stable I
+	public fun <init> ()V
+	public final fun getOnCameraMoveEnd ()Lkotlin/jvm/functions/Function2;
+	public final fun getOnCameraMoveStart ()Lkotlin/jvm/functions/Function1;
+	public final fun getOnCompassClick ()Lkotlin/jvm/functions/Function1;
+	public final fun getOnMapClick ()Lkotlin/jvm/functions/Function1;
+	public final fun getOnMapPaddingChange ()Lkotlin/jvm/functions/Function0;
+	public final fun getOnMapViewInfoChange ()Lkotlin/jvm/functions/Function1;
+	public final fun getOnPoiClick ()Lkotlin/jvm/functions/Function3;
+	public final fun getOnTerrainClick ()Lkotlin/jvm/functions/Function1;
+	public final fun setOnCameraMoveEnd (Lkotlin/jvm/functions/Function2;)V
+	public final fun setOnCameraMoveStart (Lkotlin/jvm/functions/Function1;)V
+	public final fun setOnCompassClick (Lkotlin/jvm/functions/Function1;)V
+	public final fun setOnMapClick (Lkotlin/jvm/functions/Function1;)V
+	public final fun setOnMapPaddingChange (Lkotlin/jvm/functions/Function0;)V
+	public final fun setOnMapViewInfoChange (Lkotlin/jvm/functions/Function1;)V
+	public final fun setOnPoiClick (Lkotlin/jvm/functions/Function3;)V
+	public final fun setOnTerrainClick (Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class io/hlab/vectormap/compose/settings/DimScreenType : java/lang/Enum {
+	public static final field All Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public static final field MapAndLabel Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public static final field NONE Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public static final field OnlyMap Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public static fun values ()[Lio/hlab/vectormap/compose/settings/DimScreenType;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapDirection : java/lang/Enum {
+	public static final field Bottom Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field BottomLeft Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field BottomRight Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field Center Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field Left Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field Right Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field Top Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field TopLeft Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static final field TopRight Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/hlab/vectormap/compose/settings/MapDirection;
+	public static fun values ()[Lio/hlab/vectormap/compose/settings/MapDirection;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapGestureSettings {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (ZZZZZZZZZ)V
+	public synthetic fun <init> (ZZZZZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (ZZZZZZZZZ)Lio/hlab/vectormap/compose/settings/MapGestureSettings;
+	public static synthetic fun copy$default (Lio/hlab/vectormap/compose/settings/MapGestureSettings;ZZZZZZZZZILjava/lang/Object;)Lio/hlab/vectormap/compose/settings/MapGestureSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun isLongTapAndDragEnabled ()Z
+	public final fun isOneFingerDoubleTapEnabled ()Z
+	public final fun isOneFingerZoomEnabled ()Z
+	public final fun isPanEnabled ()Z
+	public final fun isRotateEnabled ()Z
+	public final fun isRotateZoomEnabled ()Z
+	public final fun isTiltEnabled ()Z
+	public final fun isTwoFingerSingleTapEnabled ()Z
+	public final fun isZoomEnabled ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapGestureSettingsKt {
+	public static final fun getDisabledMapGestureSettings ()Lio/hlab/vectormap/compose/settings/MapGestureSettings;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapInitialOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lcom/kakao/vectormap/MapType;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/kakao/vectormap/MapType;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/kakao/vectormap/MapType;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Lcom/kakao/vectormap/MapType;Ljava/lang/String;Ljava/lang/Integer;)Lio/hlab/vectormap/compose/settings/MapInitialOptions;
+	public static synthetic fun copy$default (Lio/hlab/vectormap/compose/settings/MapInitialOptions;Ljava/lang/String;Lcom/kakao/vectormap/MapType;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/hlab/vectormap/compose/settings/MapInitialOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppName ()Ljava/lang/String;
+	public final fun getMapType ()Lcom/kakao/vectormap/MapType;
+	public final fun getStyleName ()Ljava/lang/String;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapViewSettings {
+	public static final field $stable I
+	public synthetic fun <init> (Lcom/kakao/vectormap/MapType;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;Lio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZZZLio/hlab/vectormap/compose/settings/PoiLanguage;Lcom/kakao/vectormap/PoiScale;FLjava/util/Set;Lio/hlab/vectormap/compose/settings/DimScreenType;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/kakao/vectormap/MapType;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;Lio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZZZLio/hlab/vectormap/compose/settings/PoiLanguage;Lcom/kakao/vectormap/PoiScale;FLjava/util/Set;Lio/hlab/vectormap/compose/settings/DimScreenType;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/kakao/vectormap/MapType;
+	public final fun component10 ()Z
+	public final fun component11 ()Z
+	public final fun component12 ()Z
+	public final fun component13 ()Lio/hlab/vectormap/compose/settings/PoiLanguage;
+	public final fun component14 ()Lcom/kakao/vectormap/PoiScale;
+	public final fun component15 ()F
+	public final fun component16 ()Ljava/util/Set;
+	public final fun component17 ()Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public final fun component18-0d7_KjU ()J
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun component4 ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public final fun component5 ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public final fun component6 ()Z
+	public final fun component7 ()Z
+	public final fun component8 ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public final fun component9 ()Z
+	public final fun copy-x2cCqHM (Lcom/kakao/vectormap/MapType;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;Lio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZZZLio/hlab/vectormap/compose/settings/PoiLanguage;Lcom/kakao/vectormap/PoiScale;FLjava/util/Set;Lio/hlab/vectormap/compose/settings/DimScreenType;J)Lio/hlab/vectormap/compose/settings/MapViewSettings;
+	public static synthetic fun copy-x2cCqHM$default (Lio/hlab/vectormap/compose/settings/MapViewSettings;Lcom/kakao/vectormap/MapType;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;Lio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZLio/hlab/vectormap/compose/settings/MapWidgetPosition;ZZZZLio/hlab/vectormap/compose/settings/PoiLanguage;Lcom/kakao/vectormap/PoiScale;FLjava/util/Set;Lio/hlab/vectormap/compose/settings/DimScreenType;JILjava/lang/Object;)Lio/hlab/vectormap/compose/settings/MapViewSettings;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBaseMap ()Lcom/kakao/vectormap/MapType;
+	public final fun getBuildingHeightScale ()F
+	public final fun getCompassPosition ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public final fun getDimScreenColor-0d7_KjU ()J
+	public final fun getDimScreenType ()Lio/hlab/vectormap/compose/settings/DimScreenType;
+	public final fun getFixedCenterGestures ()Ljava/util/Set;
+	public final fun getLogoPosition ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public final fun getPoiLanguage ()Lio/hlab/vectormap/compose/settings/PoiLanguage;
+	public final fun getPoiScale ()Lcom/kakao/vectormap/PoiScale;
+	public final fun getScaleBarPosition ()Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public fun hashCode ()I
+	public final fun isCameraAnimateEnabled ()Z
+	public final fun isCompassBackToNorthOnClick ()Z
+	public final fun isCompassVisible ()Z
+	public final fun isPoiClickable ()Z
+	public final fun isPoiVisible ()Z
+	public final fun isScaleBarAutoHide ()Z
+	public final fun isScaleBarVisible ()Z
+	public final fun isTrackingRotation ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/hlab/vectormap/compose/settings/MapWidgetPosition {
+	public static final field $stable I
+	public fun <init> (Lio/hlab/vectormap/compose/settings/MapDirection;FF)V
+	public synthetic fun <init> (Lio/hlab/vectormap/compose/settings/MapDirection;FFILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/hlab/vectormap/compose/settings/MapDirection;
+	public final fun component2 ()F
+	public final fun component3 ()F
+	public final fun copy (Lio/hlab/vectormap/compose/settings/MapDirection;FF)Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public static synthetic fun copy$default (Lio/hlab/vectormap/compose/settings/MapWidgetPosition;Lio/hlab/vectormap/compose/settings/MapDirection;FFILjava/lang/Object;)Lio/hlab/vectormap/compose/settings/MapWidgetPosition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMapDirection ()Lio/hlab/vectormap/compose/settings/MapDirection;
+	public final fun getXPx ()F
+	public final fun getYPx ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/hlab/vectormap/compose/settings/PoiLanguage : java/lang/Enum {
+	public static final field English Lio/hlab/vectormap/compose/settings/PoiLanguage;
+	public static final field Korean Lio/hlab/vectormap/compose/settings/PoiLanguage;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/hlab/vectormap/compose/settings/PoiLanguage;
+	public static fun values ()[Lio/hlab/vectormap/compose/settings/PoiLanguage;
+}
+

--- a/vectormap-compose/build.gradle.kts
+++ b/vectormap-compose/build.gradle.kts
@@ -17,8 +17,22 @@ android {
         jvmToolchain(17)
     }
 
+    buildFeatures {
+        compose = true
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+        freeCompilerArgs += "-Xexplicit-api=strict"
+        freeCompilerArgs += "-Xopt-in=kotlin.RequiresOptIn"
+    }
+
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidx.compose.compiler.get()
+    }
+
+    lint {
+        abortOnError = true
     }
 }
 

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -1,5 +1,7 @@
 package io.hlab.vectormap.compose
 
+import android.graphics.PointF
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -10,10 +12,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.viewinterop.AndroidView
+import com.kakao.vectormap.Compass
+import com.kakao.vectormap.GestureType
 import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.LatLng
 import com.kakao.vectormap.MapView
+import com.kakao.vectormap.MapViewInfo
+import com.kakao.vectormap.camera.CameraPosition
+import io.hlab.vectormap.compose.extension.NoPadding
 import io.hlab.vectormap.compose.extension.disposingComposition
 import io.hlab.vectormap.compose.extension.newComposition
+import io.hlab.vectormap.compose.internal.MapEventListeners
 import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 
 /**
@@ -27,11 +36,20 @@ import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 @Composable
 fun KakaoMap(
     modifier: Modifier = Modifier,
+    mapPadding: PaddingValues = NoPadding,
     onMapReady: (KakaoMap) -> Unit = {},
     onMapResumed: () -> Unit = {},
     onMapPaused: () -> Unit = {},
     onMapError: (Exception) -> Unit = {},
     onMapDestroy: () -> Unit = {},
+    onMapPaddingChange: () -> Unit = {},
+    onMapViewInfoChange: (MapViewInfo) -> Unit = {},
+    onMapClick: (LatLng) -> Unit = {},
+    onCompassClick: (Compass) -> Unit = {},
+    onPoiClick: (LatLng, String, String) -> Unit = { _, _, _ -> },
+    onTerrainClick: (LatLng, PointF) -> Unit = { _, _ -> },
+    onCameraMoveStart: (GestureType) -> Unit = {},
+    onCameraMoveEnd: (CameraPosition, GestureType) -> Unit = { _, _ -> },
     content: (@Composable () -> Unit)? = null,
 ) {
     val context = LocalContext.current
@@ -49,6 +67,16 @@ fun KakaoMap(
         it.onMapPaused = onMapPaused
         it.onMapError = onMapError
         it.onMapDestroy = onMapDestroy
+    }
+    val mapEventListeners = remember { MapEventListeners() }.also {
+        it.onMapPaddingChange = onMapPaddingChange
+        it.onMapViewInfoChange = onMapViewInfoChange
+        it.onMapClick = onMapClick
+        it.onCompassClick = onCompassClick
+        it.onPoiClick = onPoiClick
+        it.onTerrainClick = onTerrainClick
+        it.onCameraMoveStart = onCameraMoveStart
+        it.onCameraMoveEnd = onCameraMoveEnd
     }
     // compositions
     val parentComposition = rememberCompositionContext()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -1,5 +1,6 @@
 package io.hlab.vectormap.compose
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -9,6 +10,7 @@ import androidx.compose.runtime.rememberCompositionContext
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -61,6 +63,12 @@ fun KakaoMap(
     onCameraMoveEnd: (CameraPosition, GestureType) -> Unit = { _, _ -> },
     content: (@Composable () -> Unit)? = null,
 ) {
+    // Compose preview 일 때, 빈 영역을 반환해 렌더링을 허용할 수 있도록 한다.
+    if (LocalInspectionMode.current) {
+        Box(modifier = modifier)
+        return
+    }
+
     val context = LocalContext.current
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val mapView = remember { MapView(context) }

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -44,7 +44,7 @@ import io.hlab.vectormap.compose.settings.MapViewSettings
  * @param content 다양한 컴포저블을 이용해 지도 뷰를 풍부하게 사용할 수 있음.
  */
 @Composable
-fun KakaoMap(
+public fun KakaoMap(
     modifier: Modifier = Modifier,
     mapInitialOptions: MapInitialOptions = DefaultMapInitialOptions,
     mapViewSettings: MapViewSettings = DefaultMapViewSettings,

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -28,8 +28,10 @@ import io.hlab.vectormap.compose.extension.newComposition
 import io.hlab.vectormap.compose.internal.MapEventListeners
 import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 import io.hlab.vectormap.compose.internal.MapUpdater
+import io.hlab.vectormap.compose.settings.DefaultMapGestureSettings
 import io.hlab.vectormap.compose.settings.DefaultMapInitialOptions
 import io.hlab.vectormap.compose.settings.DefaultMapViewSettings
+import io.hlab.vectormap.compose.settings.MapGestureSettings
 import io.hlab.vectormap.compose.settings.MapInitialOptions
 import io.hlab.vectormap.compose.settings.MapViewSettings
 
@@ -46,6 +48,7 @@ fun KakaoMap(
     modifier: Modifier = Modifier,
     mapInitialOptions: MapInitialOptions = DefaultMapInitialOptions,
     mapViewSettings: MapViewSettings = DefaultMapViewSettings,
+    mapGestureSettings: MapGestureSettings = DefaultMapGestureSettings,
     contentDescription: String? = null,
     mapPadding: PaddingValues = NoPadding,
     onMapReady: (KakaoMap) -> Unit = {},
@@ -106,6 +109,7 @@ fun KakaoMap(
     // map settings
     val currentMapPadding by rememberUpdatedState(mapPadding)
     val currentMapViewSettings by rememberUpdatedState(mapViewSettings)
+    val currentMapGestureSettings by rememberUpdatedState(mapGestureSettings)
 
     // compositions
     val parentComposition = rememberCompositionContext()
@@ -122,6 +126,7 @@ fun KakaoMap(
                 MapUpdater(
                     mapEventListeners = mapEventListeners,
                     mapViewSettings = currentMapViewSettings,
+                    mapGestureSettings = currentMapGestureSettings,
                     mapPadding = currentMapPadding,
                 )
                 currentContent?.invoke()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -1,6 +1,5 @@
 package io.hlab.vectormap.compose
 
-import android.graphics.PointF
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -11,6 +10,8 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.viewinterop.AndroidView
 import com.kakao.vectormap.Compass
 import com.kakao.vectormap.GestureType
@@ -36,6 +37,7 @@ import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 @Composable
 fun KakaoMap(
     modifier: Modifier = Modifier,
+    contentDescription: String? = null,
     mapPadding: PaddingValues = NoPadding,
     onMapReady: (KakaoMap) -> Unit = {},
     onMapResumed: () -> Unit = {},
@@ -47,7 +49,7 @@ fun KakaoMap(
     onMapClick: (LatLng) -> Unit = {},
     onCompassClick: (Compass) -> Unit = {},
     onPoiClick: (LatLng, String, String) -> Unit = { _, _, _ -> },
-    onTerrainClick: (LatLng, PointF) -> Unit = { _, _ -> },
+    onTerrainClick: (LatLng) -> Unit = { _ -> },
     onCameraMoveStart: (GestureType) -> Unit = {},
     onCameraMoveEnd: (CameraPosition, GestureType) -> Unit = { _, _ -> },
     content: (@Composable () -> Unit)? = null,
@@ -56,7 +58,15 @@ fun KakaoMap(
     val lifecycle = LocalLifecycleOwner.current.lifecycle
     val mapView = remember { MapView(context) }
 
-    AndroidView(modifier = modifier, factory = { mapView })
+    val semantics = if (contentDescription != null) {
+        Modifier.semantics {
+            this.contentDescription = contentDescription
+        }
+    } else {
+        Modifier
+    }
+
+    AndroidView(modifier = modifier.then(semantics), factory = { mapView })
 
     // callback Containers
     // remember 를 이용해 sub-composition 을 구독해 content invoke 가 매번 일어나지 않도록 컨트롤함

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -26,6 +26,7 @@ import io.hlab.vectormap.compose.extension.newComposition
 import io.hlab.vectormap.compose.internal.MapEventListeners
 import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 import io.hlab.vectormap.compose.internal.MapUpdater
+import io.hlab.vectormap.compose.settings.MapInitialOptions
 
 /**
  * [com.kakao.vectormap.KakaoMap] 을 제공하는 컴포저블
@@ -38,6 +39,7 @@ import io.hlab.vectormap.compose.internal.MapUpdater
 @Composable
 fun KakaoMap(
     modifier: Modifier = Modifier,
+    mapInitialOptions: MapInitialOptions = MapInitialOptions(),
     contentDescription: String? = null,
     mapPadding: PaddingValues = NoPadding,
     onMapReady: (KakaoMap) -> Unit = {},
@@ -101,6 +103,7 @@ fun KakaoMap(
             mapView.newComposition(
                 lifecycle = lifecycle,
                 parentComposition = parentComposition,
+                mapInitialOptions = mapInitialOptions,
                 mapCallbackContainer = mapLifecycleCallbacks,
             ) {
                 MapUpdater(

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -26,7 +26,10 @@ import io.hlab.vectormap.compose.extension.newComposition
 import io.hlab.vectormap.compose.internal.MapEventListeners
 import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
 import io.hlab.vectormap.compose.internal.MapUpdater
+import io.hlab.vectormap.compose.settings.DefaultMapInitialOptions
+import io.hlab.vectormap.compose.settings.DefaultMapViewSettings
 import io.hlab.vectormap.compose.settings.MapInitialOptions
+import io.hlab.vectormap.compose.settings.MapViewSettings
 
 /**
  * [com.kakao.vectormap.KakaoMap] 을 제공하는 컴포저블
@@ -39,7 +42,8 @@ import io.hlab.vectormap.compose.settings.MapInitialOptions
 @Composable
 fun KakaoMap(
     modifier: Modifier = Modifier,
-    mapInitialOptions: MapInitialOptions = MapInitialOptions(),
+    mapInitialOptions: MapInitialOptions = DefaultMapInitialOptions,
+    mapViewSettings: MapViewSettings = DefaultMapViewSettings,
     contentDescription: String? = null,
     mapPadding: PaddingValues = NoPadding,
     onMapReady: (KakaoMap) -> Unit = {},
@@ -93,6 +97,7 @@ fun KakaoMap(
     }
     // map settings
     val currentMapPadding by rememberUpdatedState(mapPadding)
+    val currentMapViewSettings by rememberUpdatedState(mapViewSettings)
 
     // compositions
     val parentComposition = rememberCompositionContext()
@@ -108,6 +113,7 @@ fun KakaoMap(
             ) {
                 MapUpdater(
                     mapEventListeners = mapEventListeners,
+                    mapViewSettings = currentMapViewSettings,
                     mapPadding = currentMapPadding,
                 )
                 currentContent?.invoke()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/KakaoMap.kt
@@ -25,6 +25,7 @@ import io.hlab.vectormap.compose.extension.disposingComposition
 import io.hlab.vectormap.compose.extension.newComposition
 import io.hlab.vectormap.compose.internal.MapEventListeners
 import io.hlab.vectormap.compose.internal.MapLifecycleCallbacks
+import io.hlab.vectormap.compose.internal.MapUpdater
 
 /**
  * [com.kakao.vectormap.KakaoMap] 을 제공하는 컴포저블
@@ -88,6 +89,9 @@ fun KakaoMap(
         it.onCameraMoveStart = onCameraMoveStart
         it.onCameraMoveEnd = onCameraMoveEnd
     }
+    // map settings
+    val currentMapPadding by rememberUpdatedState(mapPadding)
+
     // compositions
     val parentComposition = rememberCompositionContext()
     val currentContent by rememberUpdatedState(content)
@@ -99,6 +103,10 @@ fun KakaoMap(
                 parentComposition = parentComposition,
                 mapCallbackContainer = mapLifecycleCallbacks,
             ) {
+                MapUpdater(
+                    mapEventListeners = mapEventListeners,
+                    mapPadding = currentMapPadding,
+                )
                 currentContent?.invoke()
             }
         }

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/extension/ComposeExtension.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/extension/ComposeExtension.kt
@@ -1,5 +1,12 @@
 package io.hlab.vectormap.compose.extension
 
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.currentComposer
+import com.kakao.vectormap.KakaoMap
+import io.hlab.vectormap.compose.internal.MapApplier
 
 internal val NoPadding = PaddingValues()
+
+@Composable
+internal fun getMap(): KakaoMap = (currentComposer.applier as MapApplier).map

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/extension/ComposeExtension.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/extension/ComposeExtension.kt
@@ -1,0 +1,5 @@
+package io.hlab.vectormap.compose.extension
+
+import androidx.compose.foundation.layout.PaddingValues
+
+internal val NoPadding = PaddingValues()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapEventListeners.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapEventListeners.kt
@@ -1,0 +1,32 @@
+package io.hlab.vectormap.compose.internal
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.kakao.vectormap.Compass
+import com.kakao.vectormap.GestureType
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.LatLng
+import com.kakao.vectormap.MapViewInfo
+import com.kakao.vectormap.camera.CameraPosition
+
+/**
+ * [KakaoMap] 의 Event Listener Container
+ *
+ * 현재 지원하는 이벤트
+ * - 지도 설정 : [onMapPaddingChange], [onMapViewInfoChange]
+ * - 지도 클릭 : [onMapClick], [onCompassClick], [onPoiClick], [onTerrainClick]
+ * - 카메라 : [onCameraMoveStart], [onCameraMoveEnd]
+ */
+class MapEventListeners {
+    var onMapPaddingChange: () -> Unit by mutableStateOf({})
+    var onMapViewInfoChange: (MapViewInfo) -> Unit by mutableStateOf({})
+
+    var onMapClick: (LatLng) -> Unit by mutableStateOf({})
+    var onCompassClick: (Compass) -> Unit by mutableStateOf({})
+    var onPoiClick: (LatLng, String, String) -> Unit by mutableStateOf({ _, _, _ -> })
+    var onTerrainClick: (LatLng) -> Unit by mutableStateOf({ _ -> })
+
+    var onCameraMoveStart: (GestureType) -> Unit by mutableStateOf({})
+    var onCameraMoveEnd: (CameraPosition, GestureType) -> Unit by mutableStateOf({ _, _ -> })
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapEventListeners.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapEventListeners.kt
@@ -18,15 +18,15 @@ import com.kakao.vectormap.camera.CameraPosition
  * - 지도 클릭 : [onMapClick], [onCompassClick], [onPoiClick], [onTerrainClick]
  * - 카메라 : [onCameraMoveStart], [onCameraMoveEnd]
  */
-class MapEventListeners {
-    var onMapPaddingChange: () -> Unit by mutableStateOf({})
-    var onMapViewInfoChange: (MapViewInfo) -> Unit by mutableStateOf({})
+public class MapEventListeners {
+    public var onMapPaddingChange: () -> Unit by mutableStateOf({})
+    public var onMapViewInfoChange: (MapViewInfo) -> Unit by mutableStateOf({})
 
-    var onMapClick: (LatLng) -> Unit by mutableStateOf({})
-    var onCompassClick: (Compass) -> Unit by mutableStateOf({})
-    var onPoiClick: (LatLng, String, String) -> Unit by mutableStateOf({ _, _, _ -> })
-    var onTerrainClick: (LatLng) -> Unit by mutableStateOf({ _ -> })
+    public var onMapClick: (LatLng) -> Unit by mutableStateOf({})
+    public var onCompassClick: (Compass) -> Unit by mutableStateOf({})
+    public var onPoiClick: (LatLng, String, String) -> Unit by mutableStateOf({ _, _, _ -> })
+    public var onTerrainClick: (LatLng) -> Unit by mutableStateOf({ _ -> })
 
-    var onCameraMoveStart: (GestureType) -> Unit by mutableStateOf({})
-    var onCameraMoveEnd: (CameraPosition, GestureType) -> Unit by mutableStateOf({ _, _ -> })
+    public var onCameraMoveStart: (GestureType) -> Unit by mutableStateOf({})
+    public var onCameraMoveEnd: (CameraPosition, GestureType) -> Unit by mutableStateOf({ _, _ -> })
 }

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapLifecycleCallbacks.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapLifecycleCallbacks.kt
@@ -1,0 +1,20 @@
+package io.hlab.vectormap.compose.internal
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import com.kakao.vectormap.KakaoMap
+
+/**
+ * [com.kakao.vectormap.KakaoMap] 의 맵에 직접 연관된 Callback 컨테이너.
+ *
+ * 맵 객체를 초기화하면서 [com.kakao.vectormap.MapLifeCycleCallback] 과
+ * [com.kakao.vectormap.MapReadyCallback] 으로 등록할 콜백을 관리한다.
+ */
+internal class MapLifecycleCallbacks {
+    var onMapReady: (KakaoMap) -> Unit by mutableStateOf({})
+    var onMapResumed: () -> Unit by mutableStateOf({})
+    var onMapPaused: () -> Unit by mutableStateOf({})
+    var onMapError: (Exception) -> Unit by mutableStateOf({})
+    var onMapDestroy: () -> Unit by mutableStateOf({})
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
@@ -12,6 +12,7 @@ import com.kakao.vectormap.MapType
 import com.kakao.vectormap.MapView
 import io.hlab.vectormap.compose.extension.getMap
 import io.hlab.vectormap.compose.internal.node.MapPropertiesNode
+import io.hlab.vectormap.compose.settings.MapGestureSettings
 import io.hlab.vectormap.compose.settings.MapViewSettings
 import io.hlab.vectormap.compose.settings.adjustDimScreenType
 
@@ -25,6 +26,7 @@ import io.hlab.vectormap.compose.settings.adjustDimScreenType
 internal inline fun MapUpdater(
     mapEventListeners: MapEventListeners,
     mapViewSettings: MapViewSettings,
+    mapGestureSettings: MapGestureSettings,
     mapPadding: PaddingValues,
 ) {
     // 지도 객체 및 화면 관련 정보
@@ -85,6 +87,20 @@ internal inline fun MapUpdater(
                 val dimScreenLayer = map.dimScreenManager?.dimScreenLayer ?: return@set
                 dimScreenLayer.setColor(color.toArgb())
             }
+            // Map Gesture Setting 설정
+            set(mapGestureSettings.isOneFingerDoubleTapEnabled) {
+                map.setGestureEnable(GestureType.OneFingerDoubleTap, it)
+            }
+            set(mapGestureSettings.isTwoFingerSingleTapEnabled) {
+                map.setGestureEnable(GestureType.TwoFingerSingleTap, it)
+            }
+            set(mapGestureSettings.isPanEnabled) { map.setGestureEnable(GestureType.Pan, it) }
+            set(mapGestureSettings.isRotateEnabled) { map.setGestureEnable(GestureType.Rotate, it) }
+            set(mapGestureSettings.isZoomEnabled) { map.setGestureEnable(GestureType.Zoom, it) }
+            set(mapGestureSettings.isTiltEnabled) { map.setGestureEnable(GestureType.Tilt, it) }
+            set(mapGestureSettings.isLongTapAndDragEnabled) { map.setGestureEnable(GestureType.LongTapAndDrag, it) }
+            set(mapGestureSettings.isRotateZoomEnabled) { map.setGestureEnable(GestureType.RotateZoom, it) }
+            set(mapGestureSettings.isOneFingerZoomEnabled) { map.setGestureEnable(GestureType.OneFingerZoom, it) }
             // EventListener 변화 감지
             update(mapEventListeners) { this.mapEventListeners = it }
         },

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
@@ -3,15 +3,28 @@ package io.hlab.vectormap.compose.internal
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.ComposeNode
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalLayoutDirection
+import com.kakao.vectormap.GestureType
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.MapType
+import com.kakao.vectormap.MapView
 import io.hlab.vectormap.compose.extension.getMap
 import io.hlab.vectormap.compose.internal.node.MapPropertiesNode
+import io.hlab.vectormap.compose.settings.MapViewSettings
+import io.hlab.vectormap.compose.settings.adjustDimScreenType
 
+/**
+ * MapProperty 를 최신 상태로 유지하기 위한 Composable.
+ *
+ * [MapUpdater] 는 [MapView] 의 Composition 범위 내에 항상 속해있으며, 컴포지션에 관여해 상태를 업데이트 할 수 있도록 한다.
+ */
 @Suppress("NOTHING_TO_INLINE")
 @Composable
 internal inline fun MapUpdater(
     mapEventListeners: MapEventListeners,
+    mapViewSettings: MapViewSettings,
     mapPadding: PaddingValues,
 ) {
     // 지도 객체 및 화면 관련 정보
@@ -36,8 +49,55 @@ internal inline fun MapUpdater(
             update(density) { this.density = it }
             update(layoutDirection) { this.layoutDirection = it }
             update(mapPadding) { this.setMapPadding(it) }
+            // Map View Setting 설정
+            update(mapViewSettings.baseMap) { mapType -> map.adjustBaseMap(mapType) }
+            set(mapViewSettings.isCameraAnimateEnabled) { map.setCameraAnimateEnable(it) }
+            set(mapViewSettings.isTrackingRotation) { map.trackingManager?.setTrackingRotation(it) }
+            set(mapViewSettings.logoPosition) { position ->
+                position?.let { map.logo?.setPosition(it.mapDirection.value, it.xPx, it.yPx) }
+            }
+            set(mapViewSettings.compassPosition) { position ->
+                position?.let { map.compass?.setPosition(it.mapDirection.value, it.xPx, it.yPx) }
+            }
+            set(mapViewSettings.isCompassVisible) { compassVisibility ->
+                if (compassVisibility) map.compass?.show() else map.compass?.hide()
+            }
+            set(mapViewSettings.isCompassBackToNorthOnClick) { map.compass?.isBackToNorthOnClick = it }
+            set(mapViewSettings.scaleBarPosition) { position ->
+                position?.let { map.scaleBar?.setPosition(it.mapDirection.value, it.xPx, it.yPx) }
+            }
+            set(mapViewSettings.isScaleBarVisible) { scaleBarVisibility ->
+                if (scaleBarVisibility) map.scaleBar?.show() else map.scaleBar?.hide()
+            }
+            set(mapViewSettings.isScaleBarAutoHide) { map.scaleBar?.isAutoHide = it }
+            set(mapViewSettings.isPoiVisible) { map.setPoiVisible(it) }
+            set(mapViewSettings.isPoiClickable) { map.setPoiClickable(it) }
+            set(mapViewSettings.poiLanguage) { map.setPoiLanguage(it.code) }
+            set(mapViewSettings.poiScale) { map.setPoiScale(it) }
+            set(mapViewSettings.buildingHeightScale) { map.buildingHeightScale = it }
+            set(mapViewSettings.fixedCenterGestures) { fixedCenterGestures ->
+                val nonFixedGestures = (gestureTypes - fixedCenterGestures).toTypedArray()
+                if (nonFixedGestures.isNotEmpty()) map.setFixedCenter(false, *nonFixedGestures)
+                if (fixedCenterGestures.isNotEmpty()) map.setFixedCenter(true, *fixedCenterGestures.toTypedArray())
+            }
+            set(mapViewSettings.dimScreenType) { map.adjustDimScreenType(it) }
+            set(mapViewSettings.dimScreenColor) { color ->
+                val dimScreenLayer = map.dimScreenManager?.dimScreenLayer ?: return@set
+                dimScreenLayer.setColor(color.toArgb())
+            }
             // EventListener 변화 감지
             update(mapEventListeners) { this.mapEventListeners = it }
         },
     )
 }
+
+private val gestureTypes = GestureType.values().toSet()
+
+/**
+ * 기본 맵 스타일을 지정합니다.
+ *
+ * 현재 아래와 같은 맵 스타일이 지원됩니다.
+ * - [MapType.NORMAL] : 기본 맵뷰
+ * - [MapType.SKYVIEW] : 스카이맵 맵뷰
+ */
+private fun KakaoMap.adjustBaseMap(mapType: MapType) = changeMapType(mapType)

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/MapUpdater.kt
@@ -1,0 +1,43 @@
+package io.hlab.vectormap.compose.internal
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.ComposeNode
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import io.hlab.vectormap.compose.extension.getMap
+import io.hlab.vectormap.compose.internal.node.MapPropertiesNode
+
+@Suppress("NOTHING_TO_INLINE")
+@Composable
+internal inline fun MapUpdater(
+    mapEventListeners: MapEventListeners,
+    mapPadding: PaddingValues,
+) {
+    // 지도 객체 및 화면 관련 정보
+    val map = getMap()
+    val density = LocalDensity.current
+    val layoutDirection = LocalLayoutDirection.current
+    // 주입받는 State 들에 대해 ComposeNode 를 recompose 해 상태를 갱신함.
+    // 매번 LayoutNode 에 대한 직접적인 recompose 가 매번 일어나는 걸 방지할 수 있음.
+    ComposeNode<MapPropertiesNode, MapApplier>(
+        factory = {
+            MapPropertiesNode(
+                map = map,
+                initialMapPadding = mapPadding,
+                mapEventListeners = mapEventListeners,
+                density = density,
+                layoutDirection = layoutDirection,
+            )
+        },
+        update = {
+            // 노드에 density 와 layoutDirection 을 가지고 있도록 함으로써
+            // 업데이트 블록이 캡쳐링 되지 않고, 컴파일러가 해당 블록을 싱글톤으로 변경할 수 있도록 한다.
+            update(density) { this.density = it }
+            update(layoutDirection) { this.layoutDirection = it }
+            update(mapPadding) { this.setMapPadding(it) }
+            // EventListener 변화 감지
+            update(mapEventListeners) { this.mapEventListeners = it }
+        },
+    )
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
@@ -51,9 +51,6 @@ internal class MapPropertiesNode(
         map.setOnMapClickListener { _, latLng, _, _ ->
             mapEventListeners.onMapClick(latLng)
         }
-        map.setOnMapClickListener { _, position, _, _ ->
-            mapEventListeners.onMapClick(position)
-        }
         map.setOnCompassClickListener { _, compass ->
             compass?.let { mapEventListeners.onCompassClick(it) }
         }

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
@@ -1,0 +1,65 @@
+package io.hlab.vectormap.compose.internal.node
+
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.LayoutDirection
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.KakaoMap.OnMapViewInfoChangeListener
+import com.kakao.vectormap.MapViewInfo
+import io.hlab.vectormap.compose.internal.MapEventListeners
+
+/**
+ * 맵 객체의 설정을 관리하는 Node
+ *
+ * 아래와 같은 책임을 이행한다.
+ * - [mapEventListeners] 를 [KakaoMap] 에 세팅
+ * - 현재 맵이 위치한 화면의 [density] 와 [layoutDirection] 를 기록, 맵 패딩 설정에 이용가능하도록 한다.
+ */
+internal class MapPropertiesNode(
+    val map: KakaoMap,
+    var mapEventListeners: MapEventListeners,
+    var density: Density,
+    var layoutDirection: LayoutDirection,
+) : MapNode {
+
+    private val onCameraMoveStartListener = KakaoMap.OnCameraMoveStartListener { _, gestureType ->
+        mapEventListeners.onCameraMoveStart(gestureType)
+    }
+
+    private val onCameraMoveEndListener = KakaoMap.OnCameraMoveEndListener { _, position, gestureType ->
+        mapEventListeners.onCameraMoveEnd(position, gestureType)
+    }
+
+    override fun onAttached() {
+        map.setOnPaddingChangeListener { _ ->
+            mapEventListeners.onMapPaddingChange()
+        }
+        map.setOnMapViewInfoChangeListener(
+            object : OnMapViewInfoChangeListener {
+                override fun onMapViewInfoChanged(mapViewInfo: MapViewInfo?) {
+                    mapViewInfo?.let { mapEventListeners.onMapViewInfoChange(it) }
+                }
+
+                override fun onMapViewInfoChangeFailed() = Unit
+            },
+        )
+        map.setOnMapClickListener { _, latLng, _, _ ->
+            mapEventListeners.onMapClick(latLng)
+        }
+        map.setOnMapClickListener { _, position, _, _ ->
+            mapEventListeners.onMapClick(position)
+        }
+        map.setOnCompassClickListener { _, compass ->
+            compass?.let { mapEventListeners.onCompassClick(it) }
+        }
+        map.setOnPoiClickListener { _, position, poiType, poiId ->
+            mapEventListeners.onPoiClick(position, poiType, poiId)
+        }
+        map.setOnTerrainClickListener { _, position, _ ->
+            mapEventListeners.onTerrainClick(position)
+        }
+        map.setOnCameraMoveStartListener(onCameraMoveStartListener)
+        map.setOnCameraMoveEndListener(onCameraMoveEndListener)
+    }
+
+    override fun onRemoved() = Unit
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/internal/node/MapPropertiesNode.kt
@@ -1,5 +1,6 @@
 package io.hlab.vectormap.compose.internal.node
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import com.kakao.vectormap.KakaoMap
@@ -16,10 +17,15 @@ import io.hlab.vectormap.compose.internal.MapEventListeners
  */
 internal class MapPropertiesNode(
     val map: KakaoMap,
+    initialMapPadding: PaddingValues,
     var mapEventListeners: MapEventListeners,
     var density: Density,
     var layoutDirection: LayoutDirection,
 ) : MapNode {
+
+    init {
+        setMapPadding(paddingValues = initialMapPadding)
+    }
 
     private val onCameraMoveStartListener = KakaoMap.OnCameraMoveStartListener { _, gestureType ->
         mapEventListeners.onCameraMoveStart(gestureType)
@@ -62,4 +68,19 @@ internal class MapPropertiesNode(
     }
 
     override fun onRemoved() = Unit
+
+    /**
+     * Map 의 Padding 을 설정하는 함수
+     */
+    internal fun setMapPadding(paddingValues: PaddingValues) {
+        val node = this
+        with(density) {
+            map.setPadding(
+                paddingValues.calculateLeftPadding(node.layoutDirection).roundToPx(),
+                paddingValues.calculateTopPadding().roundToPx(),
+                paddingValues.calculateRightPadding(node.layoutDirection).roundToPx(),
+                paddingValues.calculateBottomPadding().roundToPx(),
+            )
+        }
+    }
 }

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/DimScreenType.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/DimScreenType.kt
@@ -1,0 +1,34 @@
+package io.hlab.vectormap.compose.settings
+
+import com.kakao.vectormap.KakaoMap
+import com.kakao.vectormap.shape.DimScreenCover
+
+/**
+ * 적용할 DimScreen 을 결정합니다.
+ *
+ * - [NONE] : DimScreen 을 제거합니다. ( visible = false )
+ * - [OnlyMap] : 지도만 가리는 DimScreen 이 적용됩니다. ( 라벨은 가려지지 않습니다. )
+ * - [MapAndLabel] : 지도 및 라벨을 가리는 DimScreen 이 적용됩니다.
+ * - [All] : 전체를 다 가리는 DimScreen 이 적용됩니다.
+ */
+enum class DimScreenType {
+    NONE,
+    OnlyMap,
+    MapAndLabel,
+    All,
+}
+
+internal fun KakaoMap.adjustDimScreenType(type: DimScreenType) {
+    val dimScreen = this.dimScreenManager?.dimScreenLayer ?: return
+    if (type == DimScreenType.NONE) {
+        dimScreen.setVisible(false)
+    } else {
+        dimScreen.setVisible(true)
+        when (type) {
+            DimScreenType.OnlyMap -> dimScreen.setDimScreenCover(DimScreenCover.Map)
+            DimScreenType.MapAndLabel -> dimScreen.setDimScreenCover(DimScreenCover.MapAndLabel)
+            DimScreenType.All -> dimScreen.setDimScreenCover(DimScreenCover.All)
+            else -> error("Error on adjusting DimScreenType !")
+        }
+    }
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/DimScreenType.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/DimScreenType.kt
@@ -11,7 +11,7 @@ import com.kakao.vectormap.shape.DimScreenCover
  * - [MapAndLabel] : 지도 및 라벨을 가리는 DimScreen 이 적용됩니다.
  * - [All] : 전체를 다 가리는 DimScreen 이 적용됩니다.
  */
-enum class DimScreenType {
+public enum class DimScreenType {
     NONE,
     OnlyMap,
     MapAndLabel,

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapGestureSettings.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapGestureSettings.kt
@@ -13,7 +13,7 @@ package io.hlab.vectormap.compose.settings
  * @param isRotateZoomEnabled 회전 줌을 허용할지 여부를 지정합니다.
  * @param isOneFingerZoomEnabled 한 손가락 줌을 허용할지 여부를 지정합니다.
  */
-data class MapGestureSettings(
+public data class MapGestureSettings(
     val isOneFingerDoubleTapEnabled: Boolean = true,
     val isTwoFingerSingleTapEnabled: Boolean = true,
     val isPanEnabled: Boolean = true,
@@ -30,7 +30,7 @@ internal val DefaultMapGestureSettings = MapGestureSettings()
 /**
  * 사용자의 제스처를 모두 허용하지 않는 세팅입니다.
  */
-val DisabledMapGestureSettings = MapGestureSettings(
+public val DisabledMapGestureSettings: MapGestureSettings = MapGestureSettings(
     isOneFingerDoubleTapEnabled = false,
     isTwoFingerSingleTapEnabled = false,
     isPanEnabled = false,

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapGestureSettings.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapGestureSettings.kt
@@ -1,0 +1,43 @@
+package io.hlab.vectormap.compose.settings
+
+/**
+ * 지도 제스쳐 설정 객체.
+ *
+ * @param isOneFingerDoubleTapEnabled 한 손가락 더블-탭을 허용할지 여부를 지정합니다.
+ * @param isTwoFingerSingleTapEnabled 두 손가락 탭을 허용할지 여부를 지정합니다.
+ * @param isPanEnabled 카메라 이동을 허용할지 여부를 지정합니다.
+ * @param isRotateEnabled 카메라 회전을 허용할지 여부를 지정합니다.
+ * @param isZoomEnabled 카메라 줌을 허용할지 여부를 지정합니다.
+ * @param isTiltEnabled 카메라 기울이기를 허용할지 여부를 지정합니다.
+ * @param isLongTapAndDragEnabled 길게 누른 채로 드래그를 허용할지 여부를 지정합니다.
+ * @param isRotateZoomEnabled 회전 줌을 허용할지 여부를 지정합니다.
+ * @param isOneFingerZoomEnabled 한 손가락 줌을 허용할지 여부를 지정합니다.
+ */
+data class MapGestureSettings(
+    val isOneFingerDoubleTapEnabled: Boolean = true,
+    val isTwoFingerSingleTapEnabled: Boolean = true,
+    val isPanEnabled: Boolean = true,
+    val isRotateEnabled: Boolean = true,
+    val isZoomEnabled: Boolean = true,
+    val isTiltEnabled: Boolean = true,
+    val isLongTapAndDragEnabled: Boolean = true,
+    val isRotateZoomEnabled: Boolean = true,
+    val isOneFingerZoomEnabled: Boolean = true,
+)
+
+internal val DefaultMapGestureSettings = MapGestureSettings()
+
+/**
+ * 사용자의 제스처를 모두 허용하지 않는 세팅입니다.
+ */
+val DisabledMapGestureSettings = MapGestureSettings(
+    isOneFingerDoubleTapEnabled = false,
+    isTwoFingerSingleTapEnabled = false,
+    isPanEnabled = false,
+    isRotateEnabled = false,
+    isZoomEnabled = false,
+    isTiltEnabled = false,
+    isLongTapAndDragEnabled = false,
+    isRotateZoomEnabled = false,
+    isOneFingerZoomEnabled = false,
+)

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
@@ -14,7 +14,7 @@ import com.kakao.vectormap.MapType
  *
  * @see com.kakao.vectormap.MapReadyCallback
  */
-data class MapInitialOptions(
+public data class MapInitialOptions(
     val appName: String? = null,
     val mapType: MapType? = null,
     val styleName: String? = null,

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
@@ -20,3 +20,5 @@ data class MapInitialOptions(
     val styleName: String? = null,
     val timeout: Int? = null,
 )
+
+internal val DefaultMapInitialOptions = MapInitialOptions()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapInitialOptions.kt
@@ -1,0 +1,22 @@
+package io.hlab.vectormap.compose.settings
+
+import com.kakao.vectormap.MapType
+
+/**
+ * 맵 초기 시작 정보 설정
+ *
+ * 기존 [com.kakao.vectormap.MapReadyCallback] 을 override 해 제공하던 초기 정보를 세팅합니다.
+ *
+ * @property appName 등록된 앱 이름. 기본값은 "openmap".
+ * @property mapType 지도의 타입. 기본값은 [MapType.NORMAL].
+ * @property styleName 지도의 스타일 이름
+ * @property timeout 지도 데이터 로딩 시 Http 통신 timeout. 단위는 ms. ( 기본값 : 5000ms )
+ *
+ * @see com.kakao.vectormap.MapReadyCallback
+ */
+data class MapInitialOptions(
+    val appName: String? = null,
+    val mapType: MapType? = null,
+    val styleName: String? = null,
+    val timeout: Int? = null,
+)

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapViewSettings.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapViewSettings.kt
@@ -1,0 +1,59 @@
+package io.hlab.vectormap.compose.settings
+
+import androidx.compose.ui.graphics.Color
+import com.kakao.vectormap.GestureType
+import com.kakao.vectormap.MapType
+import com.kakao.vectormap.PoiScale
+
+/**
+ * 지도 뷰에 관련한 설정 객체.
+ *
+ * @param baseMap 맵 스타일을 지정한다. 기본값은 [MapType.NORMAL] 이다.
+ * @param isCameraAnimateEnabled 애니메이션 있는 카메라 움직임 가능 여부를 지정한다.
+ * @param isTrackingRotation 특정 라벨을 트래킹할 때 라벨이 회전 시 지도 또한 회전을 따라갈지 지정한다.
+ * @param logoPosition kakao 로고의 맵 상 위치를 지정한다.
+ * @param compassPosition 컴퍼스의 맵 상 위치를 지정한다.
+ * @param isCompassVisible 컴퍼스가 보이게 할지 여부를 지정한다.
+ * @param isCompassBackToNorthOnClick 컴퍼스 터치 시, 다시 지도 방향을 원위치 시킬지 지정한다.
+ * @param scaleBarPosition 축척의 맵 상 위치를 지정한다.
+ * @param isScaleBarVisible 축척이 보이게 할지 여부를 지정한다.
+ * @param isScaleBarAutoHide 축척이 일정 시간이 지나면 사라지게 할지 여부를 지정한다.
+ * @param isPoiVisible POI 가 보이게 할지 여부를 지정한다.
+ * @param isPoiClickable POI 가 클릭 가능하게 할지 여부를 지정한다.
+ * @param poiLanguage POI 를 표시할 언어를 지정한다.
+ * @param poiScale POI 크기 비율을 지정한다.
+ * @param buildingHeightScale 지도 빌딩 높이를 지정한다. ( 0.01 ~ 1.0 )
+ * @param fixedCenterGestures 카메라 중심이 고정된 채로 정해진 동작을 수행할 Gesture 들을 지정한다.
+ * @param dimScreenType 어떤 DimScreen 을 지도에 적용할지를 지정한다.
+ * @param dimScreenColor 현재 적용된 DimScreen 의 색상을 지정한다. ( 기본값 : 검은색 - 알파 0.2f )
+ *
+ * [com.kakao.vectormap.KakaoMap.isVisible] 은 현재 활동중인 카메라를 종료하지만, 마지막으로 보여진 스냅샷은 노출한다.
+ * 즉, 사용자에게는 단순히 visible 한 마지막 시점의 지도가 조작 불가능한 상태로 제공될 뿐이다. 이는 맵이 보이지 않게 하기 위한
+ * 기존 의도와 다르므로, API 에서 제공하지 않습니다.
+ */
+data class MapViewSettings(
+    val baseMap: MapType = MapType.NORMAL,
+    val isCameraAnimateEnabled: Boolean = true,
+    val isTrackingRotation: Boolean = true,
+    val logoPosition: MapWidgetPosition? = null,
+    val compassPosition: MapWidgetPosition? = null,
+    val isCompassVisible: Boolean = true,
+    val isCompassBackToNorthOnClick: Boolean = true,
+    val scaleBarPosition: MapWidgetPosition? = null,
+    val isScaleBarVisible: Boolean = false,
+    val isScaleBarAutoHide: Boolean = true,
+    val isPoiVisible: Boolean = true,
+    val isPoiClickable: Boolean = true,
+    val poiLanguage: PoiLanguage = PoiLanguage.Korean,
+    val poiScale: PoiScale = PoiScale.REGULAR,
+    val buildingHeightScale: Float = 0.5f,
+    val fixedCenterGestures: Set<GestureType> = emptySet(),
+    val dimScreenType: DimScreenType = DimScreenType.NONE,
+    val dimScreenColor: Color = Color.Black.copy(alpha = 0.2f),
+) {
+    init {
+        require(buildingHeightScale in 0f..1f) { "buildingHeightScale must be between 0.01f and 1f!" }
+    }
+}
+
+internal val DefaultMapViewSettings = MapViewSettings()

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapViewSettings.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapViewSettings.kt
@@ -31,7 +31,7 @@ import com.kakao.vectormap.PoiScale
  * 즉, 사용자에게는 단순히 visible 한 마지막 시점의 지도가 조작 불가능한 상태로 제공될 뿐이다. 이는 맵이 보이지 않게 하기 위한
  * 기존 의도와 다르므로, API 에서 제공하지 않습니다.
  */
-data class MapViewSettings(
+public data class MapViewSettings(
     val baseMap: MapType = MapType.NORMAL,
     val isCameraAnimateEnabled: Boolean = true,
     val isTrackingRotation: Boolean = true,

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapWidgetPosition.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapWidgetPosition.kt
@@ -1,0 +1,34 @@
+package io.hlab.vectormap.compose.settings
+
+import com.kakao.vectormap.MapGravity
+
+/**
+ * [com.kakao.vectormap.KakaoMap] 에서 지원하는 위젯의 포지션 정보를 담는 Data Util
+ *
+ * 카카오 지도 SDK 의 경우, 각 위젯들의 포지션에 대해 setPosition 함수를 통해 제공하고 있는데,
+ * 컴포저블에서 파라미터를 통해 이를 쉽게 설정할 수 있도록 지원하기 위해서 해당 Data Util 을 지원합니다.
+ *
+ * @param mapDirection [com.kakao.vectormap.MapGravity] 값을 이용한 정렬 정보
+ * @param xPx x축 패딩 값. 기본값은 0 입니다.
+ * @param yPx y축 패딩 값. 기본값은 0 입니다.
+ */
+data class MapWidgetPosition(
+    val mapDirection: MapDirection,
+    val xPx: Float = 0f,
+    val yPx: Float = 0f,
+)
+
+/**
+ * 쉽게 위젯의 방향을 설정할 수 있도록 제공하는 Data Util
+ */
+enum class MapDirection(internal val value: Int) {
+    Center(MapGravity.CENTER),
+    Top(MapGravity.TOP or MapGravity.CENTER_HORIZONTAL),
+    Right(MapGravity.RIGHT or MapGravity.CENTER_VERTICAL),
+    Bottom(MapGravity.BOTTOM or MapGravity.CENTER_HORIZONTAL),
+    Left(MapGravity.LEFT or MapGravity.CENTER_VERTICAL),
+    TopLeft(MapGravity.TOP or MapGravity.LEFT),
+    TopRight(MapGravity.TOP or MapGravity.RIGHT),
+    BottomRight(MapGravity.BOTTOM or MapGravity.RIGHT),
+    BottomLeft(MapGravity.BOTTOM or MapGravity.LEFT),
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapWidgetPosition.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/MapWidgetPosition.kt
@@ -12,7 +12,7 @@ import com.kakao.vectormap.MapGravity
  * @param xPx x축 패딩 값. 기본값은 0 입니다.
  * @param yPx y축 패딩 값. 기본값은 0 입니다.
  */
-data class MapWidgetPosition(
+public data class MapWidgetPosition(
     val mapDirection: MapDirection,
     val xPx: Float = 0f,
     val yPx: Float = 0f,
@@ -21,7 +21,7 @@ data class MapWidgetPosition(
 /**
  * 쉽게 위젯의 방향을 설정할 수 있도록 제공하는 Data Util
  */
-enum class MapDirection(internal val value: Int) {
+public enum class MapDirection(internal val value: Int) {
     Center(MapGravity.CENTER),
     Top(MapGravity.TOP or MapGravity.CENTER_HORIZONTAL),
     Right(MapGravity.RIGHT or MapGravity.CENTER_VERTICAL),

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/PoiLanguage.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/PoiLanguage.kt
@@ -1,0 +1,11 @@
+package io.hlab.vectormap.compose.settings
+
+/**
+ * 지도 객체의 Poi 표현 언어를 결정합니다.
+ *
+ * - [Korean] : Poi 를 한글로 표시합니다.
+ * - [English] : Poi 를 영어로 표시합니다.
+ */
+enum class PoiLanguage(internal val code: String) {
+    Korean("ko"), English("en")
+}

--- a/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/PoiLanguage.kt
+++ b/vectormap-compose/src/main/kotlin/io/hlab/vectormap/compose/settings/PoiLanguage.kt
@@ -6,6 +6,6 @@ package io.hlab.vectormap.compose.settings
  * - [Korean] : Poi 를 한글로 표시합니다.
  * - [English] : Poi 를 영어로 표시합니다.
  */
-enum class PoiLanguage(internal val code: String) {
+public enum class PoiLanguage(internal val code: String) {
     Korean("ko"), English("en")
 }


### PR DESCRIPTION
<!--
    Create PR with title like "[(subject)] (description)".
-->
## Description
### Add fundamentals to load `KakaoMap` on Composable
- fe4f957 : MapLifecycleCallbacks which provide container for lifecycle-callback ( e.g. onMapReady, etc. )
- 35e2384 : MapEventListeners which provide container for event-callback ( e.g. onMapClick, etc. )
- 3891746 : MapInitialOptions which provide options adapted on map-initialization
- 05228d5 : MapViewSettings which provide settings for Map UI
- b78c03b : MapGestureSettings which provide settings for Map Gesture-enable

5b5ad39, 26ed7a4
MapPropertiesNode is a node class that hold map's listener callbacks to retain on composition-lifecycle.
MapUpdater provides the compose-node holding `MapPropertiesNode`.

### Add project-level dependencies
dokka, kotlin-binary-compatibility-validator, etc.

## References
<!-- Write related PRs or references' links. -->

## Checklist
<!-- 
    Mark x instead of whitespace.
    ex:
    - [x] ~~
    - [ ] ~~
-->
- [x] Add labels and reviewers ?
- [x] Are you fully explaining what you changed ?
- [x] Did you check that there is no conflict with the base branch ?